### PR TITLE
Do not use `json.load()` to generate the `__red_end_user_data_statement__` as it can be error prone.

### DIFF
--- a/{{cookiecutter.package_name}}/__init__.py
+++ b/{{cookiecutter.package_name}}/__init__.py
@@ -5,8 +5,7 @@ from redbot.core.bot import Red
 
 from .{{cookiecutter.package_name}} import {{cookiecutter.cog_class_name}}
 
-with open(Path(__file__).parent / "info.json") as fp:
-    __red_end_user_data_statement__ = json.load(fp)["end_user_data_statement"]
+__red_end_user_data_statement__ = "{{ cookiecutter.end_user_data_statement }}"
 
 
 async def setup(bot: Red) -> None:


### PR DESCRIPTION
As the title suggest, move the cookiecutter template to use the static string provided in the cookiecutter, so that errors raised due to an invalid key, or missing file are not raised to users.

If/when red adds an util for simpler handling here then this can be updated to use that util instead.