### PR TITLE
Add $schema to cog's info.json

### DIFF
--- a/{{cookiecutter.package_name}}/info.json
+++ b/{{cookiecutter.package_name}}/info.json
@@ -5,6 +5,7 @@ are added here for convenience, but they're not part of cookiecutter template.
 {% set authors = cookiecutter.authors.split(";") -%}
 {% set tags = cookiecutter.tags.split() -%}
 {
+    "$schema": "https://raw.githubusercontent.com/Cog-Creators/Red-DiscordBot/V3/develop/schema/red_cog.schema.json",
     "name": "{{ cookiecutter.cog_class_name }}",
     "short": "{{ cookiecutter.short }}",
     "description": "{{ cookiecutter.description }}",


### PR DESCRIPTION
This add the `$schema` key to the cog's info.json, useful to add more extra properties, and be able to use the new keys easily in the future if more are added.