### PR TITLE
Add `await` to `bot.add_cog()` call

### DIFF
--- a/{{cookiecutter.package_name}}/__init__.py
+++ b/{{cookiecutter.package_name}}/__init__.py
@@ -10,4 +10,4 @@ with open(Path(__file__).parent / "info.json") as fp:
 
 
 async def setup(bot: Red) -> None:
-    bot.add_cog({{cookiecutter.cog_class_name}}(bot))
+    await bot.add_cog({{cookiecutter.cog_class_name}}(bot))

--- a/{{cookiecutter.package_name}}/info.json
+++ b/{{cookiecutter.package_name}}/info.json
@@ -17,7 +17,7 @@ are added here for convenience, but they're not part of cookiecutter template.
     "required_cogs": {},
     "requirements": [],
     "tags": {{ tags | jsonify | indent }},
-    "min_bot_version": "3.3.10",
+    "min_bot_version": "3.5.0",
     "hidden": false,
     "disabled": false,
     "type": "COG"


### PR DESCRIPTION
Since Red 3.5 the `bot.add_cog()` function is now asynchronous and needs to be awaited for the cog to be successfully registered.

This change literally just adds an `await` for it.